### PR TITLE
Add GreatCTO — multi-agent SDLC orchestration plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Fixie is a platform for conversational AI that enables to build agents in any la
 
 ## [GreatCTO](https://greatcto.systems/)
 
-Open-source Claude Code plugin orchestrating 33 specialist AI agents through the full SDLC pipeline — architect, planning, implementation, 12-angle review, QA, security, deployment, support — across 25 project archetypes (web, fintech, healthcare, edtech, gov-public, insurance, etc.) with auto-attached compliance gates (PCI-DSS, HIPAA, GDPR, FedRAMP, EU AI Act).
+Open-source MIT plugin for Claude Code. Its one job is to report what did NOT happen: a skipped stage, a review that never ran and an unmeasured cost each render as themselves and are never counted as a pass. Three approvals stay yours — what gets built, how, and whether it ships — and spending caps refuse rather than warn. On OpenAI Codex it ships a skills bundle and an MCP server, and Codex reviews the same diff as a cross-model second opinion.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ Fixie is a platform for conversational AI that enables to build agents in any la
 
 </details>
 
+## [GreatCTO](https://greatcto.systems/)
+
+Open-source Claude Code plugin orchestrating 33 specialist AI agents through the full SDLC pipeline — architect, planning, implementation, 12-angle review, QA, security, deployment, support — across 25 project archetypes (web, fintech, healthcare, edtech, gov-public, insurance, etc.) with auto-attached compliance gates (PCI-DSS, HIPAA, GDPR, FedRAMP, EU AI Act).
+
+<details>
+
+<!-- ### Description -->
+
+
+### Links
+- [Web](https://greatcto.systems/)
+- [GitHub](https://github.com/avelikiy/great_cto)
+- [npm](https://www.npmjs.com/package/great-cto)
+- [JSR](https://jsr.io/@avelikiy/great-cto)
+
+
+</details>
+
 ## [Helicone](https://www.helicone.ai/)
 An open-source observability platform for GPT-3. Allows to track usage, costs, and latency with one line of code.
 


### PR DESCRIPTION
## What

Adds **GreatCTO** to the list — an open-source Claude Code plugin that orchestrates 33 specialist AI agents through the full SDLC pipeline.

## Why it fits

GreatCTO is exactly the kind of "framework for creating, monitoring, debugging and deploying autonomous AI agents" this list is for:

- **33 specialist agents** — architect, PM, senior-dev, code-reviewer, QA, security-officer, DevOps, plus 26 archetype-specific reviewers (PCI, Oracle, Regulated, AI-Security, Firmware, Web-Store, etc.)
- **Auto archetype detection** — scans `package.json`, `pyproject.toml`, `Cargo.toml`, README to pick from 25 project types
- **Auto-attached compliance gates** — PCI-DSS, HIPAA, SOX, GDPR, FedRAMP, EU AI Act, COPPA/FERPA, NAIC, SOC2 — based on archetype
- **Built-in security scanner** — `npx great-cto scan ./` covers OWASP LLM Top 10 (prompt injection, secrets in prompts, SSRF, RAG poisoning, cost runaway), outputs SARIF for GitHub Code Scanning
- **Continuous learning loop** — extracts session patterns into project-local lessons + cross-project decisions
- **Observability** — `great-cto board` opens 6-view dashboard with live SSE updates

## Stats

- npm: [`great-cto@2.2.0`](https://www.npmjs.com/package/great-cto)
- JSR: [`@avelikiy/great-cto@2.2.0`](https://jsr.io/@avelikiy/great-cto)
- License: MIT
- 8 languages (EN + RU + ZH-CN + ZH-TW + JA + KO + ES + PT-BR)
- 141 / 141 tests passing

## Format

Followed the existing entry format exactly — alphabetical position (between Fixie and Helicone), `## [Name](URL)` heading, one-line tagline, `<details>` block with Web + GitHub links.

Happy to adjust the description if you'd like it shorter or tweaked. Thanks!