### PR TITLE
Add Runback

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ A unified platform for debugging, testing, evaluating, and monitoring LLM applic
 
 </details>
 
+## [Runback](https://runback.dev/)
+Runback captures every agent run and makes it re-executable — replay any step against the exact context the model saw, gate releases in CI, and export a signed record an auditor can verify independently.
+
+<details>
+
+<!-- ### Description -->
+
+### Links
+- [Web](https://runback.dev/)
+- [GitHub](https://github.com/letsRunback/runback-community)
+- [Docs](https://runback.dev/docs)
+
+
+</details>
+
+
 ## [SID](https://www.sid.ai/)
 
 SID is a YC S23 company that makes data infrastructure for AI easy by letting AI devs connect to all of their customer's data with a single button and API.


### PR DESCRIPTION
Adds **Runback**, in alphabetical position between LangSmith and SID.

Runback captures agent runs and makes them re-executable: replay any step against the exact context the model saw rather than a reconstruction, gate releases in CI against a dataset, and export a signed record that an auditor can verify independently — offline, with an MIT-licensed CLI, no account required.

Posting here rather than `awesome-ai-agents`, per that repo's note that it is for AI assistants and agents while SDKs and tooling belong in this list.

**Licence:** the Community edition is source-available rather than OSI open source — self-host, read, modify and redistribute freely; the one restriction is no hosted resale. Saying so up front rather than leaving it to be discovered.

- Site: https://runback.dev
- Repo: https://github.com/letsRunback/runback-community (v0.1.0)